### PR TITLE
(lex) Add support for numeric literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "./types/"
   ],
   "dependencies": {
-    "commander": "^2.12.2"
+    "commander": "^2.12.2",
+    "node-int64": "^0.4.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.10",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.5.2",
+    "@types/node-int64": "^0.4.29",
     "chai": "^4.1.2",
     "mocha": "^4.0.1",
     "typescript": "^2.6.2"

--- a/src/Lexeme.ts
+++ b/src/Lexeme.ts
@@ -31,7 +31,10 @@ export enum Lexeme {
     // literals
     Identifier,
     String,
-    Number,
+    Integer,
+    Float,
+    Double,
+    LongInteger,
 
     // other single-character symbols
     Dot,

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -1,5 +1,7 @@
-import { Lexeme } from "./Lexeme";
-import { Token } from "./Token";
+import Int64 = require("node-int64");
+
+import { Lexeme} from "./Lexeme";
+import { Token, Literal } from "./Token";
 import * as OrbsError from "./Error";
 
 let start: number;
@@ -120,7 +122,11 @@ function scanToken() {
                 break;
             }
         default:
-            OrbsError.make(`Unexpected character '${c}'`, line);
+            if (isDigit(c)) {
+                number();
+            } else {
+                OrbsError.make(`Unexpected character '${c}'`, line);
+            }
             break;
     }
 }
@@ -188,7 +194,116 @@ function string() {
     addToken(Lexeme.String, value);
 }
 
-function addToken(kind: Lexeme, literal?: string): void {
+function isDigit(char: string) {
+    if (char.length > 1) {
+        throw new Error(`Lexer#isDigit expects a single character; received '${char}'`);
+    }
+
+    return char >= "0" && char <= "9";
+}
+
+function number() {
+    let containsDecimal = false;
+    while (isDigit(peek())) { advance(); }
+
+    // look for a fractional portion
+    if (peek() === "." && isDigit(peekNext())) {
+        containsDecimal = true;
+
+        // consume the "." parse the fractional part
+        advance();
+
+        // read the remaining digits
+        while (isDigit(peek())) { advance(); }
+    }
+
+    let asString = source.slice(start, current);
+    let numberOfDigits = containsDecimal ? asString.length - 1 : asString.length;
+
+    if (numberOfDigits >= 10) {
+        // numeric literals over 10 digits are automatically Doubles
+        addToken(Lexeme.Double, Number.parseFloat(asString));
+        return;
+    } else if (peek() === "#") {
+        // numeric literals ending with "#" are forced to Doubles
+        advance();
+        asString = source.slice(start, current);
+        addToken(Lexeme.Double, Number.parseFloat(asString));
+        return;
+    } else if (peek().toLowerCase() === "d") {
+        // literals that use "D" as the exponent are also automatic Doubles
+        
+        // consume the "D"
+        advance();
+
+        // exponents are optionally signed
+        // TODO: Confirm this in BrightScript documentation!
+        if (peek() === "+" || peek() === "-") {
+            advance();
+        }
+
+        // consume the exponent
+        while (isDigit(peek())) { advance(); }
+
+        // replace the exponential marker with a JavaScript-friendly "e"
+        asString = source.slice(start, current).replace(/[dD]/, "e");
+        addToken(Lexeme.Double, Number.parseFloat(asString));
+        return;
+    }
+
+    if (peek() === "!") {
+        // numeric literals ending with "!" are forced to Floats
+        advance();
+        asString = source.slice(start, current);
+        addToken(
+            Lexeme.Float,
+            Math.fround(Number.parseFloat(asString))
+        );
+        return;
+    } else if (peek().toLowerCase() === "e") {
+        // literals that use "E" as the exponent are also automatic Floats
+        
+        // consume the "E"
+        advance();
+
+        // exponents are optionally signed
+        // TODO: Confirm this in BrightScript documentation!
+        if (peek() === "+" || peek() === "-") {
+            advance();
+        }
+
+        // consume the exponent
+        while (isDigit(peek())) { advance(); }
+
+        asString = source.slice(start, current);
+        addToken(
+            Lexeme.Float,
+            Math.fround(Number.parseFloat(asString))
+        );
+        return;
+    } else if (containsDecimal) {
+        // anything with a decimal but without matching Double rules is a Float
+        addToken(
+            Lexeme.Float,
+            Math.fround(Number.parseFloat(asString))
+        );
+        return;
+    }
+
+    if (peek() === "&") {
+        // numeric literals ending with "&" are forced to LongIntegers
+        advance();
+        asString = source.slice(start, current);
+        addToken(Lexeme.LongInteger, new Int64(asString));
+        return;
+    } else {
+        // otherwise, it's a regular integer
+        addToken(Lexeme.Integer, Number.parseInt(asString, 10));
+        return;
+    }
+}
+
+function addToken(kind: Lexeme, literal?: Literal): void {
     tokens.push({
         kind: kind,
         text: source.slice(start, current),

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -36,7 +36,7 @@ function isAtEnd() {
 
 function scanToken() {
     let c = advance();
-    switch (c) {
+    switch (c.toLowerCase()) {
         case "(": addToken(Lexeme.LeftParen); break;
         case ")": addToken(Lexeme.RightParen); break;
         case "{": addToken(Lexeme.LeftBrace); break;
@@ -80,7 +80,6 @@ function scanToken() {
                 default: addToken(Lexeme.Greater); break;
             }
             break;
-        case "M":
         case "m":
             if (peek().toLowerCase() === "o" && peekNext().toLowerCase() === "d") {
                 addToken(Lexeme.Mod);
@@ -109,7 +108,6 @@ function scanToken() {
         case "\"":
             string();
             break;
-        case "R":
         case "r":
             // brightscript allows the `rem` keyword to start comments in addition to
             // `'` prefixes

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -1,10 +1,12 @@
 import { Lexeme } from "./Lexeme";
+import Int64 = require("node-int64");
 
-export type invalid = undefined;
+export type Invalid = undefined;
+export type Literal = string | number | Int64 | boolean;
 
 export interface Token {
     kind: Lexeme;
     text?: string;
-    literal?: string | Number | true | false;
+    literal?: Literal;
     line: number;
 }

--- a/test/Lexer.js
+++ b/test/Lexer.js
@@ -1,4 +1,6 @@
 const { assert } = require("chai");
+const Int64 = require("node-int64");
+
 const Lexer = require("../lib/Lexer");
 const { Lexeme } = require("../lib/Lexeme");
 
@@ -178,4 +180,65 @@ describe("lexer", function() {
         it("produces an error for unterminated strings");
         it("disallows multiline strings");
     }); // string literals
+
+    context("double literals", function() {
+        it("respects '#' suffix", function() {
+            let d = Lexer.scan("123#")[0];
+            assert.equal(d.kind, Lexeme.Double, "Should produce a double token");
+            assert.equal(d.literal, 123, "Should contain a double-precision value");
+        });
+
+        it("forces literals >= 10 digits into doubles", function() {
+            let d = Lexer.scan("0000000005")[0];
+            assert.equal(d.kind, Lexeme.Double, "Should produce a double token");
+            assert.equal(d.literal, 5, "Should contain a double-precision value");
+        });
+
+        it("forces literals with 'D' in exponent into doubles", function() {
+            let d = Lexer.scan("2.5d3")[0];
+            assert.equal(d.kind, Lexeme.Double, "Should produce a double token");
+            assert.equal(d.literal, 2500, "Should contain a double-precision value");
+        });
+    });
+
+    context("float literals", function() {
+        it("respects '!' suffix", function() {
+            let f = Lexer.scan("0.00000008!")[0];
+            assert.equal(f.kind, Lexeme.Float, "Should produce a float token");
+            // Floating precision will make this *not* equal
+            assert.notEqual(f.literal, 8e-8, "Should contain a single-precision value");
+            assert.equal(f.literal, Math.fround(0.00000008), "Should contain a single-precision value");
+        });
+
+        it("forces literals with a decimal into floats", function() {
+            let f = Lexer.scan("1.0")[0];
+            assert.equal(f.kind, Lexeme.Float, "Should produce a float token");
+            assert.equal(f.literal, Math.fround(1000000000000e-12), "Should contain a single-precision value");
+        });
+
+        it("forces literals with 'E' in exponent into floats", function() {
+            let d = Lexer.scan("2.5e3")[0];
+            assert.equal(d.kind, Lexeme.Float, "Should produce a float token");
+            assert.equal(d.literal, 2500, "Should contain a single-precision value");
+        });
+    });
+
+    context("long integer literals", function() {
+        it("supports hexadecimal literals");
+        it("respects '&' suffix", function() {
+            let li = Lexer.scan("123&")[0];
+            assert.equal(li.kind, Lexeme.LongInteger, "Should produce a long integer token");
+            assert.deepEqual(li.literal, new Int64("123"), "Should contain a long integer value");
+        });
+    });
+
+    context("integer literals", function() {
+        it("supports hexadecimal literals");
+        it("falls back to a regular integer", function() {
+            let i = Lexer.scan("123")[0];
+            assert.equal(i.kind, Lexeme.Integer, "Should produce an integer token");
+            assert.isTrue(Number.isInteger(i.literal), "Should contain an integer value");
+            assert.equal(i.literal, 123, "Should contain an integer value");
+        });
+    });
 }); // lexer

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,13 @@
   version "2.2.44"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.44.tgz#1d4a798e53f35212fd5ad4d04050620171cd5b5e"
 
-"@types/node@^8.5.2":
+"@types/node-int64@^0.4.29":
+  version "0.4.29"
+  resolved "https://registry.yarnpkg.com/@types/node-int64/-/node-int64-0.4.29.tgz#8c7c16a7c1195ae4f8beaa903b0018ac66291d16"
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*", "@types/node@^8.5.2":
   version "8.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.2.tgz#83b8103fa9a2c2e83d78f701a9aa7c9539739aa5"
 
@@ -156,6 +162,10 @@ mocha@^4.0.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+node-int64@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
Still need to work out hexadecimal literals, but this includes:

1. Double-precision floats
2. Single-precision floats
3. 64-bit integers
4. 32-bit integers

I'm _pretty sure_ I got the rules right from the BrightScript spec?
https://sdkdocs.roku.com/display/sdkdoc/Expressions%2C+Variables%2C+and+Types#Expressions,Variables,andTypes-NumericLiterals