### PR TITLE
removed a couple of verification TODO comments

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -237,7 +237,6 @@ function number() {
         advance();
 
         // exponents are optionally signed
-        // TODO: Confirm this in BrightScript documentation!
         if (peek() === "+" || peek() === "-") {
             advance();
         }
@@ -267,7 +266,6 @@ function number() {
         advance();
 
         // exponents are optionally signed
-        // TODO: Confirm this in BrightScript documentation!
         if (peek() === "+" || peek() === "-") {
             advance();
         }


### PR DESCRIPTION
I couldn't find any docs on this, but verified on a Roku.  

```
a = 1.23456789D+12 
b = 1.23456789D-12 
c = 1.23456789D12 
d = 1.23456789E+12 
e = 1.23456789E-12 
f = 1.23456789E12 

?type(a)
?type(b)
?type(c)
?type(d)
?type(e)
?type(f)
```

Types and values:

```
Double
Double
Double
Float
Float
Float

```