### PR TITLE
(build) Use `rimraf` to clean instead of `rm -rf`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "orbs": "./bin/cli.js"
   },
   "scripts": {
-    "build": "tsc -p .",
-    "clean": "rm -rf ./lib ./types",
+    "build": "tsc",
+    "clean": "rimraf ./lib ./types",
     "test": "mocha"
   },
   "files": [
@@ -29,6 +29,7 @@
     "@types/node-int64": "^0.4.29",
     "chai": "^4.1.2",
     "mocha": "^4.0.1",
+    "rimraf": "^2.6.2",
     "typescript": "^2.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,7 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
-glob@7.1.2:
+glob@7.1.2, glob@^7.0.5:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -180,6 +180,12 @@ path-is-absolute@^1.0.0:
 pathval@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
+rimraf@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
 
 supports-color@4.4.0:
   version "4.4.0"


### PR DESCRIPTION
The `rimraf` package runs in `node` directly, meaning the `clean` target can now run on Windows platforms.

I don't have a Windows machine handy to test this on, but I'll trust `rimraf` 🤷‍♂️ 