### PR TITLE
Started defining a formal grammar for brightscript

### DIFF
--- a/src/grammar/BrightscriptGrammer.ebnf
+++ b/src/grammar/BrightscriptGrammer.ebnf
@@ -1,0 +1,196 @@
+(*
+    This is an attempt at defining a formal grammar of the brightscript language that we can iterate on and
+    define as we continue to implement the parser. This is written in EBNF syntax (but using regex
+    to instead represent required/optional symbols or groupings).
+    
+    Note: Any words that are fully capitalized represent a lexeme (see full enum in lexeme.ts) whose text
+    representation may vary or where deems appropriate (e.g. the 'Integer' lexeme can represent any valid integer, 
+    so we reference the 'Integer' lexeme here as 'INTEGER', but the 'True' lexeme only represents the value 'true' 
+    so we instead just reference the text value here as 'true' to be explicit). 
+
+    QRC (Quick Regex Cheatsheet)
+        *  - zero or more
+        +  - one or more
+        ?  - zero or one
+*)
+
+
+(* Start from the top, a brightscript script will have a number of "statements" before reaching the end of the file *)
+program
+    : statementList? EOF
+    ;
+
+statementList
+    : multiStatement+
+    ;
+
+(* In brightscript you can have several statements on the same line separated by a colon *)
+multiStatement
+    : singleStatement (":" singleStatement)* NEWLINE
+    ;
+
+singleStatement
+    : expressionStatement
+    | ifStatement
+    | methodStatement
+    ;
+
+(* 
+    Expressions 
+*)
+
+expressionStatement
+    : expression
+    ;
+
+expression
+    : assignmentExpression
+    ;
+
+assignmentExpression
+    : conditionalExpression
+    | assignment
+    ;
+
+assignment
+    : IDENTIFIER assignmentOperator expression
+    ;
+
+assignmentOperator
+    : ("=" | "*=" | "/=" | "\=" | "+=" | "-=" | "<<=" | ">>=")
+    ;
+
+(* 
+    These expression rules start from the lower-precedence and proceeds to the higher precedence (Logical and/or -> Primary) 
+    which is also known as "top-down", meaning you reach the lowest-precedence expressions first because they may in turn  
+    contain subexpressions of higher precedence. 
+    Operator Precedence: https://sdkdocs.roku.com/display/sdkdoc/Expressions%2C+Variables%2C+and+Types
+*)
+conditionalExpression
+    : conditionalOrExpression
+    ;
+
+conditionalOrExpression
+    : conditionalAndExpression ("or" conditionalAndExpression)*
+    ;
+
+conditionalAndExpression
+    : unaryNotExpression ("and" unaryNotExpression)*
+    ;
+
+unaryNotExpression
+    : relationalExpression ("not" relationalExpression)*
+    ;
+
+relationalExpression
+    : shiftExpression (("=" | "<" | ">" | "<=" | ">=" | "<>") shiftExpression)*
+    ;
+
+shiftExpression
+    : additiveExpression (("<<" | ">>") additiveExpression)*
+    ;
+
+additiveExpression
+    : multiplicativeExpression (("+" | "-") multiplicativeExpression)*
+    ;
+
+multiplicativeExpression
+    : unaryExpression (("*" | "/" | "MOD" | "\") unaryExpression)*
+    ;
+
+unaryExpression
+    : exponentiationExpression
+    | ("+" | "-") unaryExpression
+    ;
+
+exponentiationExpression
+    : primary ("^" primary)*
+    ;
+
+(* Primary expressions are the highest level of precedence *)
+primary
+    : literal
+    | IDENTIFIER
+    | "(" expression ")"
+    ;
+
+(* 
+    Since we know the literal text of the True/False/Invalid lexemes we just reference
+    their text value here to be explicit
+*)
+literal
+    : "true"
+    | "false"
+    | "invalid"
+    | STRING
+    | INTEGER
+    | FLOAT
+    | DOUBLE
+    | LONG_INTEGER
+    ;
+
+(* 
+    Conditionals 
+*)
+
+ifStatement
+    : multilineIfStatement
+    ;
+
+multilineIfStatement
+    : "if" expression "then" statementList elseIfStatement* "end if"
+    ;
+
+elseIfStatement
+    : "else" ("if" expression "then")? statementList
+    ;
+
+(*
+    Functions
+*)
+
+methodStatement
+    : functionMethod
+    | subMethod
+    ;
+
+functionMethod
+    : "function" methodDeclarator definedAsType? methodBody "end function"
+    ;
+
+subMethod
+    : "sub" methodDeclarator methodBody "end sub"
+    ;
+
+methodDeclarator
+    : IDENTIFIER "(" parameterList? ")"
+    ;
+
+methodBody
+    : statementList
+    ;
+
+parameterList
+    : parameter ("," parameter)*
+    ;
+
+parameter
+    : IDENTIFIER ("=" expression)? definedAsType?
+    ;
+
+definedAsType
+    : "as" functionReturnAndParamTypes
+    ;
+
+(* the different types that a function can return and param can be? This may need to be changed *)
+functionReturnAndParamTypes
+    : "integer"
+    | "float"
+    | "double"
+    | "boolean"
+    | "string"
+    | "object"
+    | "dynamic"
+    | "function"
+    | "void"
+    ;


### PR DESCRIPTION
**Note: I'm primarily sending out this PR as a talking point to see if you all would be interested in having and iterating on a grammar file. I personally see this as a larger benefit in the medium-long run when we start trying to parse more complicated syntax trees, but I think it could also benefit us these earlier stages as well.** @sjbarag @strattonbrazil 

With that said, I began to lay out some basic brightscript grammar which should be a good base for further iteration and could also possibly help guide the parser's development direction. But depending on how you guys feel, if we are OK with this approach then this should be a good enough base to merge in. But regardless i'm definitely open to hearing what you guys think and answer any questions. For what I _do_ have here I tried to make sure everything I defined was according to brightscript docs, but please let me know of any questions or if you spot anything out of place.

**I've added grammar to support the following:**
- a full program
- _basic_ assignment and conditional expressions following operational precedence (does not include post-fix operations)
  - x = 10
  - y *= 50.5
  - x <= 2 ^ (20 mod 4)
  - z = x or y : x = y and z

-  a block if/else if/ else statement
```
  if x < 20 then
    y = 20
  else if x < 30 then
    y = 30
  else
    y = 0
  end if
```
- method _declaration_
```
  function add (a as integer, b as integer) as integer
  ... statements ...
  end function

  sub print(val)
  ... statements ...
  end sub 
```







