### PR TITLE
(arch) Rename project to "BRS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,55 @@
-# ORBS: Off-Roku BrightScript
+# BRS: Off-Roku BrightScript
 An interpreter for the BrightScript language that runs on non-Roku platforms.
 
 ## Installation
-ORBS is published as a `node` package, so use `npm`:
+The BRS project is published as a `node` package, so use `npm`:
 
 ```shell
-$ npm install -g orbs
+$ npm install -g brs
 ```
 
 or `yarn` if that's your preference:
 
 ```shell
-$ yarn global add orbs
+$ yarn global add brs
 ```
 
 ## Usage
-This repo provides the `orbs` executable, which operates in two ways.
+This repo provides the `brs` executable, which operates in two ways.
 
 ### REPL
-An interactive BrightScript REPL (Read-Execute-Print Loop) is available by running `orbs` with no arguments, e.g.:
+An interactive BrightScript REPL (Read-Execute-Print Loop) is available by running `brs` with no arguments, e.g.:
 
 ```
-$ orbs
-ORBS> ?"Dennis Ritchie said ""Hello, World!"""
+$ brs
+brs> ?"Dennis Ritchie said ""Hello, World!"""
 Dennis Ritchie said "Hello, World!"
 ```
 
 Quit by entering `^D` (Control-D).
 
 ### Executing a file
-ORBS can execute an arbitrary BrightScript file as well!  Simply pass the file to the `orbs` executable, e.g.:
+BRS can execute an arbitrary BrightScript file as well!  Simply pass the file to the `brs` executable, e.g.:
 
 ```
 $ cat hello-world.brs
 ?"Dennis Ritchie said ""Hello, World!"""
 
-$ orbs hello-world.brs
+$ brs hello-world.brs
 Dennis Ritchie said "Hello, World!"
 ```
 
 ## Sure, but why?
-The [Roku](https://roku.com) series of media streaming devices are wildly popular amongst consumers, and several [very](https://netflix.com) [popular](https://hulu.com) [streaming](https://amazon.com/primevideo) [services](https://crackle.com) offer Channels for the Roku platform.  Unfortunately, Roku chanels *must* be written in a language called BrightScript, which is only executable directly on a Roku device.  ORBS hopes to change that by allowing Roku developers to test their code on their own machines, thus improving the quality of their channels and the end-user's experience as a whole.
+The [Roku](https://roku.com) series of media streaming devices are wildly popular amongst consumers, and several [very](https://netflix.com) [popular](https://hulu.com) [streaming](https://amazon.com/primevideo) [services](https://crackle.com) offer Channels for the Roku platform.  Unfortunately, Roku chanels *must* be written in a language called BrightScript, which is only executable directly on a Roku device.  BRS hopes to change that by allowing Roku developers to test their code on their own machines, thus improving the quality of their channels and the end-user's experience as a whole.
 
 ## So can I use this to watch TV without a Roku?
-Nope!  The ORBS project currently has no intention of emulating the Roku user interface, integrating with the Roku store, or emulating content playback.  In addition to likely getting this project in legal trouble, that sort of emulation is a ton of work.  ORBS isn't mature enough to be able to sustain that yet.
+Nope!  The BRS project currently has no intention of emulating the Roku user interface, integrating with the Roku store, or emulating content playback.  In addition to likely getting this project in legal trouble, that sort of emulation is a ton of work.  BRS isn't mature enough to be able to sustain that yet.
 
 ## Building from source
-ORBS follows pretty standard `node` development patterns, with the caveat that it uses `yarn` for dependency management.
+The BRS project follows pretty standard `node` development patterns, with the caveat that it uses `yarn` for dependency management.
 
 ### Prerequisites
-ORBS builds (and runs) in `node`, so you'll need to [install that first](https://nodejs.org).
+BRS builds (and runs) in `node`, so you'll need to [install that first](https://nodejs.org).
 
 Once that's ready, install [yarn](https://yarnpkg.com).  Installing it with `npm` is probably the simplest:
 
@@ -59,7 +59,7 @@ $ npm install -g yarn
 ### Setup
 1. Clone this repo:
    ```
-   $ git clone https://github.com/sjbarag/orbs.git
+   $ git clone https://github.com/sjbarag/brs.git
    ```
 
 2. Install dependencies:
@@ -67,7 +67,7 @@ $ npm install -g yarn
     $ yarn install     # or just `yarn`
     ```
 
-3. Get `orbs` onto your `PATH`:
+3. Get `brs` onto your `PATH`:
     ``` shell
     $ yarn link
     ```

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,7 +3,7 @@ const program = require("commander");
 const fs = require("fs");
 const path = require("path");
 
-const orbs = require("../lib/");
+const brs = require("../lib/");
 
 // read current version from package.json
 // I'll _definitely_ forget to do this one day
@@ -17,14 +17,14 @@ let brsFile;
 
 program
     .description("Off-Roku BrightScript interpreter")
-    .arguments("orbs <filename>")
+    .arguments("brs <filename>")
     .action((filename) => brsFile = filename)
     .version(packageJson.version);
 
 let args = program.parse(process.argv);
 
 if (brsFile) {
-    orbs.execute(brsFile);
+    brs.execute(brsFile);
 } else {
-    orbs.repl();
+    brs.repl();
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "orbs",
+  "name": "brs",
   "version": "0.1.0",
   "description": "An interpreter for the BrightScript language that runs on non-Roku platforms.",
   "author": "Sean Barag <sean@barag.org>",
@@ -7,7 +7,7 @@
   "main": "index.js",
   "typings": "./types/index.d.ts",
   "bin": {
-    "orbs": "./bin/cli.js"
+    "brs": "./bin/cli.js"
   },
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
     "jest": "^22.0.4",
     "rimraf": "^2.6.2",
     "typescript": "^2.6.2"
-  }
+  },
+  "repository": "https://github.com/sjbarag/brs"
 }

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -3,7 +3,7 @@ import Int64 = require("node-int64");
 import { Lexeme } from "./Lexeme";
 import { Token, Literal } from "./Token";
 import { ReservedWords } from "./ReservedWords";
-import * as OrbsError from "./Error";
+import * as BrsError from "./Error";
 
 let start: number;
 let current: number;
@@ -107,7 +107,7 @@ function scanToken() {
             } else if (isAlpha(c)) {
                 identifier();
             } else {
-                OrbsError.make(`Unexpected character '${c}'`, line);
+                BrsError.make(`Unexpected character '${c}'`, line);
             }
             break;
     }
@@ -154,7 +154,7 @@ function string() {
 
         if (peekNext() === "\n") {
             // BrightScript doesn't support multi-line strings
-            OrbsError.make("Unterminated string at end of line", line);
+            BrsError.make("Unterminated string at end of line", line);
             return;
         }
         // if (peekNext() === "\"") { advance();}
@@ -164,7 +164,7 @@ function string() {
 
     if (isAtEnd()) {
         // terminating a string with EOF is also not allowed
-        OrbsError.make("Unterminated string at end of file", line);
+        BrsError.make("Unterminated string at end of file", line);
         return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,13 @@ import { Token } from "./Token";
 import * as Lexer from "./Lexer";
 import * as Parser from "./parser";
 import { AstPrinter } from "./parser/AstPrinter";
-import * as OrbsError from "./Error";
+import * as BrsError from "./Error";
 
 
 export function execute(filename: string) {
     fs.readFile(filename, "utf-8", (err, contents) => {
         run(contents);
-        if (OrbsError.found()) {
+        if (BrsError.found()) {
             process.exit(1);
         }
     });
@@ -22,12 +22,12 @@ export function repl() {
         input: process.stdin,
         output: process.stdout,
     });
-    rl.setPrompt("ORBS> ");
+    rl.setPrompt("brs> ");
 
     rl.on("line", (line) => {
         run(line);
 
-        OrbsError.reset();
+        BrsError.reset();
         rl.prompt();
     });
 
@@ -38,7 +38,7 @@ function run(contents: string) {
     const tokens: ReadonlyArray<Token> = Lexer.scan(contents);
     const expr = Parser.parse(tokens);
 
-    if (OrbsError.found()) {
+    if (BrsError.found()) {
         return;
     }
 

--- a/src/parser/ParseError.ts
+++ b/src/parser/ParseError.ts
@@ -1,5 +1,5 @@
 import { Token } from "../Token";
-import * as OrbsError from "../Error";
+import * as BrsError from "../Error";
 import { Lexeme } from "../Lexeme";
 
 export function make(token: Token, message: string) {
@@ -7,7 +7,7 @@ export function make(token: Token, message: string) {
     if (token.kind === Lexeme.Eof) {
         m = "(At end of file) " + message;
     }
-    OrbsError.make(m, token.line);
+    BrsError.make(m, token.line);
 
     return new ParseError();
 }

--- a/test/parser/Additive.test.js
+++ b/test/parser/Additive.test.js
@@ -1,12 +1,12 @@
 const Parser = require("../../lib/parser");
 const Expr = require("../../lib/parser/Expression");
 const { Lexeme } = require("../../lib/Lexeme");
-const OrbsError = require("../../lib/Error");
+const BrsError = require("../../lib/Error");
 
 const { token, EOF } = require("./ParserTests");
 
 describe("parser", () => {
-    afterEach(() => OrbsError.reset());
+    afterEach(() => BrsError.reset());
     describe("additive expressions", () => {
         it("parses left-associative addition chains", () => {
             let parsed = Parser.parse([

--- a/test/parser/Exponential.test.js
+++ b/test/parser/Exponential.test.js
@@ -1,11 +1,11 @@
 const Parser = require("../../lib/parser");
 const { Lexeme } = require("../../lib/Lexeme");
-const OrbsError = require("../../lib/Error");
+const BrsError = require("../../lib/Error");
 
 const { token, EOF } = require("./ParserTests");
 
 describe("parser", () => {
-    afterEach(() => OrbsError.reset());
+    afterEach(() => BrsError.reset());
 
     describe("exponential expressions", () => {
         it("parses exponential operators", () => {

--- a/test/parser/Multiplicative.test.js
+++ b/test/parser/Multiplicative.test.js
@@ -1,12 +1,12 @@
 const Parser = require("../../lib/parser");
 const Expr = require("../../lib/parser/Expression");
 const { Lexeme } = require("../../lib/Lexeme");
-const OrbsError = require("../../lib/Error");
+const BrsError = require("../../lib/Error");
 
 const { token, EOF } = require("./ParserTests");
 
 describe("parser", () => {
-    afterEach(() => OrbsError.reset());
+    afterEach(() => BrsError.reset());
 
     describe("multiplicative expressions", () => {
         it("parses left-associative multiplication chains", () => {

--- a/test/parser/ParserTests.js
+++ b/test/parser/ParserTests.js
@@ -1,6 +1,6 @@
 const { Lexeme } = require("../../lib/Lexeme");
 
-/* A set of utilities to be used while writing tests for the ORBS parser. */
+/* A set of utilities to be used while writing tests for the BRS parser. */
 
 /**
  * Creates a token with the given `kind` and (optional) `literal` value.

--- a/test/parser/Primary.test.js
+++ b/test/parser/Primary.test.js
@@ -1,12 +1,12 @@
 const Parser = require("../../lib/parser");
 const Expr = require("../../lib/parser/Expression");
 const { Lexeme } = require("../../lib/Lexeme");
-const OrbsError = require("../../lib/Error");
+const BrsError = require("../../lib/Error");
 
 const { token, EOF } = require("./ParserTests");
 
 describe("parser", () => {
-    afterEach(() => OrbsError.reset());
+    afterEach(() => BrsError.reset());
 
     describe("primary expressions", () => {
         it("parses literals", () => {

--- a/test/parser/Relational.test.js
+++ b/test/parser/Relational.test.js
@@ -1,11 +1,11 @@
 const Parser = require("../../lib/parser");
 const { Lexeme } = require("../../lib/Lexeme");
-const OrbsError = require("../../lib/Error");
+const BrsError = require("../../lib/Error");
 
 const { token, EOF } = require("./ParserTests");
 
 describe("parser", () => {
-    afterEach(() => OrbsError.reset());
+    afterEach(() => BrsError.reset());
 
     describe("relational expressions", () => {
         it("parses less-than expressions", () => {

--- a/test/parser/Unary.test.js
+++ b/test/parser/Unary.test.js
@@ -1,12 +1,12 @@
 const Parser = require("../../lib/parser");
 const Expr = require("../../lib/parser/Expression");
 const { Lexeme } = require("../../lib/Lexeme");
-const OrbsError = require("../../lib/Error");
+const BrsError = require("../../lib/Error");
 
 const { token, EOF } = require("./ParserTests");
 
 describe("parser", () => {
-    afterEach(() => OrbsError.reset());
+    afterEach(() => BrsError.reset());
 
     describe("unary expressions", () => {
         it("parses unary 'not'", () => {


### PR DESCRIPTION
`brs` is one fewer character than `orbs`, and matches the BrightScript file extension.  While I love the semantics of `Off Roku BrightScript => orbs`, the `orbs` package is already taken anyway.

so it goes